### PR TITLE
VAL-11733 Remove commit validations from GitHub action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: 'Check pull request info'
-description: 'Check the last commit message in pr and the body of the pr against a regex pattern'
+description: 'Check the body and title of the pr against a regex pattern'
 author: 'Valence'
 inputs:
   body:
@@ -8,22 +8,13 @@ inputs:
   title:
     description: 'title of pr in json format'
     required: true
-  commits:
-    description: 'commits of pr in json format'
-    required: true
-  commits_pattern:
-    description: 'A regex pattern to check if a commit message is valid.'
-    required: true
+
   body_pattern:
     description: 'A regex pattern to check if the pr body is valid.'
     required: true
   title_pattern:
     description: 'A regex pattern to check if the pr body is valid.'
     required: true
-  commits_flags:
-    description: 'Expression flags change how the expression is interpreted.'
-    required: false
-    default: ''
   body_flags:
     description: 'Expression flags change how the expression is interpreted.'
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -93,7 +93,6 @@ var __importStar = (this && this.__importStar) || (function () {
     };
 })();
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getCommitInputs = getCommitInputs;
 exports.getBodyInputs = getBodyInputs;
 exports.getTitleInputs = getTitleInputs;
 exports.checkArgs = checkArgs;
@@ -105,16 +104,6 @@ const core = __importStar(__nccwpck_require__(7484));
  *
  * @returns   ICheckerArguments
  */
-function getCommitInputs() {
-    const result = {};
-    // Get pattern
-    result.pattern = core.getInput("commits_pattern", { required: true });
-    // Get flags
-    result.flags = core.getInput("commits_flags");
-    // Get error message
-    result.error = core.getInput("error", { required: true });
-    return result;
-}
 function getBodyInputs() {
     const result = {};
     // Get pattern
@@ -219,32 +208,15 @@ function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
             const bodyString = core.getInput("body");
-            const commitsString = core.getInput("commits");
             const titleString = core.getInput("title");
             const checkerArgumentsBody = inputHelper.getBodyInputs();
-            const checkerArgumentsCommmit = inputHelper.getCommitInputs();
             const checkerArgumentsTitle = inputHelper.getTitleInputs();
             const preErrorMsg = core.getInput("pre_error");
             const postErrorMsg = core.getInput("post_error");
             const failed = [];
-            const authors = [];
-            const snykBot = "snyk-bot";
-            const dependabot = "dependabot[bot]";
-            if (bodyString !== "" && commitsString !== "" && titleString !== "") {
+            if (bodyString !== "" && titleString !== "") {
                 const bodyJason = JSON.parse(bodyString);
-                const commitsJason = JSON.parse(commitsString);
                 const titleJason = JSON.parse(titleString);
-                for (const { commit } of commitsJason) {
-                    if (!authors.includes(commit.author.name))
-                        authors.push(commit.author.name);
-                    if (snykBot === commit.author.name || dependabot === commit.author.name)
-                        break;
-                    inputHelper.checkArgs(checkerArgumentsCommmit);
-                    const errMsg = infoChecker.checkInfoMessages(checkerArgumentsCommmit, commit.message);
-                    if (errMsg) {
-                        failed.push({ message: "commit: " + commit.message });
-                    }
-                }
                 for (const { body } of bodyJason) {
                     inputHelper.checkArgs(checkerArgumentsBody);
                     const errMsg = infoChecker.checkInfoMessages(checkerArgumentsBody, body);
@@ -260,13 +232,7 @@ function run() {
                         failed.push({ message: "title: " + title });
                     }
                 }
-                if (failed.length > 0 &&
-                    !authors.includes(snykBot) &&
-                    !authors.includes(dependabot)) {
-                    failed.push({ message: "The authors are: " + authors.toString() });
-                    failed.push({
-                        message: "Allowed authors: " + snykBot + ", " + dependabot,
-                    });
+                if (failed.length > 0) {
                     const summary = inputHelper.genOutput(failed, preErrorMsg, postErrorMsg);
                     core.setFailed(summary);
                 }

--- a/lib/input-helper.js
+++ b/lib/input-helper.js
@@ -33,7 +33,6 @@ var __importStar = (this && this.__importStar) || (function () {
     };
 })();
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.getCommitInputs = getCommitInputs;
 exports.getBodyInputs = getBodyInputs;
 exports.getTitleInputs = getTitleInputs;
 exports.checkArgs = checkArgs;
@@ -45,16 +44,6 @@ const core = __importStar(require("@actions/core"));
  *
  * @returns   ICheckerArguments
  */
-function getCommitInputs() {
-    const result = {};
-    // Get pattern
-    result.pattern = core.getInput("commits_pattern", { required: true });
-    // Get flags
-    result.flags = core.getInput("commits_flags");
-    // Get error message
-    result.error = core.getInput("error", { required: true });
-    return result;
-}
 function getBodyInputs() {
     const result = {};
     // Get pattern

--- a/lib/main.js
+++ b/lib/main.js
@@ -49,32 +49,15 @@ function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
             const bodyString = core.getInput("body");
-            const commitsString = core.getInput("commits");
             const titleString = core.getInput("title");
             const checkerArgumentsBody = inputHelper.getBodyInputs();
-            const checkerArgumentsCommmit = inputHelper.getCommitInputs();
             const checkerArgumentsTitle = inputHelper.getTitleInputs();
             const preErrorMsg = core.getInput("pre_error");
             const postErrorMsg = core.getInput("post_error");
             const failed = [];
-            const authors = [];
-            const snykBot = "snyk-bot";
-            const dependabot = "dependabot[bot]";
-            if (bodyString !== "" && commitsString !== "" && titleString !== "") {
+            if (bodyString !== "" && titleString !== "") {
                 const bodyJason = JSON.parse(bodyString);
-                const commitsJason = JSON.parse(commitsString);
                 const titleJason = JSON.parse(titleString);
-                for (const { commit } of commitsJason) {
-                    if (!authors.includes(commit.author.name))
-                        authors.push(commit.author.name);
-                    if (snykBot === commit.author.name || dependabot === commit.author.name)
-                        break;
-                    inputHelper.checkArgs(checkerArgumentsCommmit);
-                    const errMsg = infoChecker.checkInfoMessages(checkerArgumentsCommmit, commit.message);
-                    if (errMsg) {
-                        failed.push({ message: "commit: " + commit.message });
-                    }
-                }
                 for (const { body } of bodyJason) {
                     inputHelper.checkArgs(checkerArgumentsBody);
                     const errMsg = infoChecker.checkInfoMessages(checkerArgumentsBody, body);
@@ -90,13 +73,7 @@ function run() {
                         failed.push({ message: "title: " + title });
                     }
                 }
-                if (failed.length > 0 &&
-                    !authors.includes(snykBot) &&
-                    !authors.includes(dependabot)) {
-                    failed.push({ message: "The authors are: " + authors.toString() });
-                    failed.push({
-                        message: "Allowed authors: " + snykBot + ", " + dependabot,
-                    });
+                if (failed.length > 0) {
                     const summary = inputHelper.genOutput(failed, preErrorMsg, postErrorMsg);
                     core.setFailed(summary);
                 }

--- a/src/input-helper.ts
+++ b/src/input-helper.ts
@@ -7,21 +7,6 @@ import { ICheckerArguments } from "./info-checker";
  *
  * @returns   ICheckerArguments
  */
-export function getCommitInputs(): ICheckerArguments {
-  const result = {} as unknown as ICheckerArguments;
-
-  // Get pattern
-  result.pattern = core.getInput("commits_pattern", { required: true });
-
-  // Get flags
-  result.flags = core.getInput("commits_flags");
-
-  // Get error message
-  result.error = core.getInput("error", { required: true });
-
-  return result;
-}
-
 export function getBodyInputs(): ICheckerArguments {
   const result = {} as unknown as ICheckerArguments;
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,36 +5,16 @@ import * as infoChecker from "./info-checker";
 async function run(): Promise<void> {
   try {
     const bodyString = core.getInput("body");
-    const commitsString = core.getInput("commits");
     const titleString = core.getInput("title");
     const checkerArgumentsBody = inputHelper.getBodyInputs();
-    const checkerArgumentsCommmit = inputHelper.getCommitInputs();
     const checkerArgumentsTitle = inputHelper.getTitleInputs();
     const preErrorMsg = core.getInput("pre_error");
     const postErrorMsg = core.getInput("post_error");
     const failed = [];
-    const authors: string[] = [];
-    const snykBot = "snyk-bot";
-    const dependabot = "dependabot[bot]";
 
-    if (bodyString !== "" && commitsString !== "" && titleString !== "") {
+    if (bodyString !== "" && titleString !== "") {
       const bodyJason = JSON.parse(bodyString);
-      const commitsJason = JSON.parse(commitsString);
       const titleJason = JSON.parse(titleString);
-      for (const { commit } of commitsJason) {
-        if (!authors.includes(commit.author.name))
-          authors.push(commit.author.name);
-        if (snykBot === commit.author.name || dependabot === commit.author.name)
-          break;
-        inputHelper.checkArgs(checkerArgumentsCommmit);
-        const errMsg = infoChecker.checkInfoMessages(
-          checkerArgumentsCommmit,
-          commit.message,
-        );
-        if (errMsg) {
-          failed.push({ message: "commit: " + commit.message });
-        }
-      }
       for (const { body } of bodyJason) {
         inputHelper.checkArgs(checkerArgumentsBody);
         const errMsg = infoChecker.checkInfoMessages(
@@ -58,15 +38,7 @@ async function run(): Promise<void> {
         }
       }
 
-      if (
-        failed.length > 0 &&
-        !authors.includes(snykBot) &&
-        !authors.includes(dependabot)
-      ) {
-        failed.push({ message: "The authors are: " + authors.toString() });
-        failed.push({
-          message: "Allowed authors: " + snykBot + ", " + dependabot,
-        });
+      if (failed.length > 0) {
         const summary = inputHelper.genOutput(
           failed,
           preErrorMsg,


### PR DESCRIPTION
- Removed commits input parameter from action.yml
- Removed commit validation logic from main.ts
- Removed getCommitInputs() function from input-helper.ts
- Updated action description to reflect body and title validation only
- Rebuilt distribution files